### PR TITLE
Added NSKernAttributeName to handle certain cases where paragraph sty…

### DIFF
--- a/Pod/Classes/RUTextSize/RUAttributesDictionaryBuilder.m
+++ b/Pod/Classes/RUTextSize/RUAttributesDictionaryBuilder.m
@@ -63,6 +63,7 @@
 	if (self.lineSpacing)
 	{
 		[style setLineSpacing:self.lineSpacing.floatValue];
+        [attributesDictionary setObject:self.lineSpacing forKey:NSKernAttributeName];
 	}
 
 	[attributesDictionary setObjectOrRemoveIfNil:style forKey:NSParagraphStyleAttributeName];

--- a/Pod/Classes/RUTextSize/RUAttributesDictionaryBuilder.m
+++ b/Pod/Classes/RUTextSize/RUAttributesDictionaryBuilder.m
@@ -63,7 +63,7 @@
 	if (self.lineSpacing)
 	{
 		[style setLineSpacing:self.lineSpacing.floatValue];
-        [attributesDictionary setObject:self.lineSpacing forKey:NSKernAttributeName];
+		[attributesDictionary setObject:self.lineSpacing forKey:NSKernAttributeName];
 	}
 
 	[attributesDictionary setObjectOrRemoveIfNil:style forKey:NSParagraphStyleAttributeName];


### PR DESCRIPTION
@BenMaer 

Added NSKernAttributeName to createDictionary in RUAttributesDictionary to account for line spacing on UILabels where paragraph styles weren't doing the trick.

Impetus was this task for Qude: https://app.asana.com/0/56643802124181/56611183571894
